### PR TITLE
ポインタの座標の計算方法を修正

### DIFF
--- a/src/input/input.js
+++ b/src/input/input.js
@@ -111,11 +111,12 @@
 
       // adjust scale
       var elm = this.domElement;
-      if (elm.style.width) {
-        this._tempPosition.x *= elm.width / parseInt(elm.style.width);
+      var rect = elm.getBoundingClientRect();
+      if (rect.width) {
+        this._tempPosition.x *= elm.width / rect.width;
       }
-      if (elm.style.height) {
-        this._tempPosition.y *= elm.height / parseInt(elm.style.height);
+      if (rect.height) {
+        this._tempPosition.y *= elm.height / rect.height;
       }
     },
 

--- a/test/game/src/input.js
+++ b/test/game/src/input.js
@@ -6,7 +6,7 @@ th.describe("input.Input", function() {
       var s = e.app.domElement.style;
       s.top = '';
       s.width = '80%';
-      s.height = '100%';
+      s.height = '120%';
     };
     
     this.onpointstart = function(e) {

--- a/test/game/src/input.js
+++ b/test/game/src/input.js
@@ -1,3 +1,26 @@
+th.describe("input.Input", function() {
+
+  th.it('adjust_scale', function() {
+    
+    this.onenter = function(e) {
+      var s = e.app.domElement.style;
+      s.top = '';
+      s.width = '80%';
+      s.height = '100%';
+    };
+    
+    this.onpointstart = function(e) {
+      var p = e.pointer;
+      phina.display.CircleShape({
+        x: p.x,
+        y: p.y,
+      }).addChildTo(this);
+    };
+    
+  });
+
+});
+
 th.describe("input.Keyboard", function() {
 
   th.it('init', function() {


### PR DESCRIPTION
canvasの位置とサイズによってポインタの座標を正確に計算するようにしました。

cssのwidthやheight, transformのscale, translate等でcanvasの位置を自由に動かしてもクリックの判定がずれないようになりました。

`/test/game/#input.Input/adjust_scale` にテストを追加しました。