### PR TITLE
BaseAppの_loop内でinteractive.checkのタイミングを変更

### DIFF
--- a/src/app/baseapp.js
+++ b/src/app/baseapp.js
@@ -163,9 +163,8 @@ phina.namespace(function() {
 
     _loop: function() {
       this._update();
-      this._draw();
-
       this.interactive.check(this.currentScene);
+      this._draw();
 
       // stats update
       if (this.stats) this.stats.update();


### PR DESCRIPTION
描画後にinteractiveのcheckをしていたのを描画前にするようにしました。
以下、改善される項目です

- pointer系のイベントでの処理が1フレーム遅れずに反映される