### PR TITLE
BaseApp killメソッド実装

### DIFF
--- a/src/app/baseapp.js
+++ b/src/app/baseapp.js
@@ -32,13 +32,19 @@ phina.namespace(function() {
 
     run: function() {
       var self = this;
-
-      this.ticker.tick(function() {
+      this._loopCaller = function() {
         self._loop();
-      });
+      };
+      this.ticker.tick(this._loopCaller);
 
       this.ticker.start();
 
+      return this;
+    },
+
+    kill: function() {
+      this.ticker.stop();
+      this.ticker.untick(this._loopCaller);
       return this;
     },
 

--- a/src/util/ticker.js
+++ b/src/util/ticker.js
@@ -26,11 +26,16 @@
       this.frame = 0;
       this.deltaTime = 0;
       this.elapsedTime = 0;
+      this.isPlaying = true;
       this.runner = phina.util.Ticker.runner;
     },
 
     tick: function(func) {
       this.on('tick', func);
+    },
+
+    untick: function(func) {
+      this.off('tick', func);
     },
 
     run: function() {
@@ -58,12 +63,13 @@
 
     start: function() {
       var self = this;
-
+      this.isPlaying = true;
       this.startTime = this.currentTime = (new Date()).getTime();
-      var runner = self.runner;
       var fn = function() {
-        var delay = self.run();
-        runner(fn, delay);
+        if (self.isPlaying) {
+          var delay = self.run();
+          self.runner(fn, delay);
+        }
       };
       fn();
 
@@ -75,7 +81,8 @@
     },
 
     stop: function() {
-      // TODO: 
+      this.isPlaying = false;
+      return this;
     },
 
     rewind: function() {

--- a/test/game/src/app.js
+++ b/test/game/src/app.js
@@ -72,3 +72,28 @@ th.describe("app.Element", function() {
     console.log(JSON.stringify(elm.toJSON(), null, '  '));
   });
 });
+
+th.describe("app.BaseApp", function() {
+
+  th.it('kill', function() {
+    phina.display.StarShape({
+      x: 320,
+      y: 480,
+      radius: 100,
+    }).addChildTo(this).on('enterframe', function() {
+      this.rotation += 5;
+    });
+    
+    phina.ui.Button({
+      text: '1秒間kill',
+      x: 320,
+      y: 480,
+    }).addChildTo(this).on('push', function() {
+      var app = this.app;
+      app.kill();
+      setTimeout(function() {
+        app.run();
+      }, 1000);
+    }.bind(this));
+  });
+});


### PR DESCRIPTION
BaseAppにkillメソッドを実装しました。

appをkillした場合、appの参照がなくなれば、完全にメモリから解放されることを想定しています。

- kill() を実行した時 ticker の tick イベントリスナから削除されていることを確認
- ticker の stop() を実行した次のフレームから ticker の runner が呼ばれないことを確認
- kill() 後に run() で再起動できることを確認