### PR TITLE
Interactiveの仕様変更(DOM風にする)

### DIFF
--- a/src/app/interactive.js
+++ b/src/app/interactive.js
@@ -159,28 +159,22 @@ phina.namespace(function() {
       obj._overFlags[p.id] = overFlag;
       var targetEvents = [];
 
-      if (!prevOverFlag && overFlag) {
-        if (!events.pointover._end) {
-          targetEvents.push(events.pointover);
-        }
+      if (!prevOverFlag && overFlag && !events.pointover._end) {
+        targetEvents.push(events.pointover);
         if (obj.boundingType && obj.boundingType !== 'none') {
           this._holds.push(obj);
         }
       }
-      if (prevOverFlag && !overFlag) {
-        if (!events.pointout._end) {
-          targetEvents.push(events.pointout);
-        }
+      if (prevOverFlag && !overFlag && !events.pointout._end) {
+        targetEvents.push(events.pointout);
         this._holds.erase(obj);
       }
 
-      if (overFlag && p.getPointingStart()) {
+      if (overFlag && !events.pointstart._end && p.getPointingStart()) {
         obj._touchFlags[p.id] = true;
-        if (!events.pointstart._end) {
-          targetEvents.push(events.pointstart);
-          // クリックフラグを立てる
-          obj._clicked = true;
-        }
+        targetEvents.push(events.pointstart);
+        // クリックフラグを立てる
+        obj._clicked = true;
       }
 
       if (obj._touchFlags[p.id]) {
@@ -190,19 +184,15 @@ phina.namespace(function() {
         if (!events.pointmove._end && p._moveFlag) {
           targetEvents.push(events.pointmove);
         }
-      }
-
-      if (obj._touchFlags[p.id] === true && p.getPointingEnd()) {
-        obj._touchFlags[p.id] = false;
-        if (!events.pointend._end) {
+        if (!events.pointend._end && p.getPointingEnd()) {
+          obj._touchFlags[p.id] = false;
           targetEvents.push(events.pointend);
-        }
-        if (phina.isMobile() && overFlag) {
-          obj._overFlags[p.id] = false;
-          if (!events.pointout._end) {
+
+          if (!events.pointout._end && overFlag && phina.isMobile()) {
+            obj._overFlags[p.id] = false;
             targetEvents.push(events.pointout);
+            this._holds.erase(obj);
           }
-          this._holds.erase(obj);
         }
       }
 

--- a/src/app/interactive.js
+++ b/src/app/interactive.js
@@ -179,9 +179,9 @@ phina.namespace(function() {
         obj._touchFlags[p.id] = true;
         if (!events.pointstart._end) {
           targetEvents.push(events.pointstart);
+          // クリックフラグを立てる
+          obj._clicked = true;
         }
-        // クリックフラグを立てる
-        obj._clicked = true;
       }
 
       if (obj._touchFlags[p.id]) {

--- a/src/app/interactive.js
+++ b/src/app/interactive.js
@@ -118,6 +118,12 @@ phina.namespace(function() {
       if (element.interactive) {
         // イベント発火対象のイベントの配列を取得
         var targetEvents = this._checkPoint(element, p);
+        // 後ろに重なってる場合の対応
+        if (element._overFlags[p.id]) {
+          events.pointover._end = true;
+          events.pointout._end = true;
+        }
+
         targetEvents.forEach(function(event) {
           // targetを発火元の要素に設定
           event.target = element;

--- a/src/app/interactive.js
+++ b/src/app/interactive.js
@@ -9,6 +9,7 @@ phina.namespace(function() {
       this.app = app;
       this._enable = true;
       this.multiTouch = true;
+      this.events = {};
       this.cursor = {
         normal: '',
         hover: 'pointer',
@@ -41,47 +42,117 @@ phina.namespace(function() {
       }
 
       if (!this._enable || !this.app.pointers) return ;
-      this._checkElement(root);
+
+      if (this.multiTouch) {
+        this.app.pointers.forEach(function(p) {
+          if (p.id !== null) {
+            this._initEvents(p);
+            this._checkElement(root, p);
+          }
+        }, this);
+      }
+      else {
+        this._initEvents(this.app.pointer);
+        this._checkElement(root, this.app.pointer);
+      }
     },
 
-    _checkElement: function(element) {
+    _initEvents: function(pointer) {
+      var self = this;
+      [
+        'pointstart',
+        'pointmove',
+        'pointend',
+        'pointover',
+        'pointout',
+        'pointstay',
+      ].forEach(function(eventName) {
+        self._initEvent(eventName, pointer, []);
+      });
+    },
+
+    _initEvent: function(eventName, pointer, path) {
+      this.events[eventName] = {
+        type: eventName,
+        target: null,
+        path: path,
+        pointer: pointer,
+        interactive: this,
+        // 親要素へイベントを伝播するか
+        stop: false,
+        // 一度イベントが発火しても、続行して背面の要素までイベントを発火させるか
+        pass: false,
+        _end: false,
+      };
+    },
+
+    _checkElement: function(element, p) {
       var app = this.app;
 
       // 更新するかを判定
       if (element.awake === false) return ;
 
+      var events = this.events;
+      var allEnded = true;
+
+      for (var k in events) {
+        var e = events[k];
+        if (!e._end) {
+          allEnded = false;
+          e.path.unshift(element);
+        }
+      }
+      if (allEnded) {
+        return;
+      }
       // 子供を更新
       var len = element.children.length;
-      if (element.children.length > 0) {
+      if (len > 0) {
         var tempChildren = element.children.slice();
-        for (var i=0; i<len; ++i) {
-          this._checkElement(tempChildren[i]);
+        for (var i = len - 1; i >= 0; --i) {
+          this._checkElement(tempChildren[i], p);
         }
       }
 
       // タッチ判定
-      this._checkPoint(element);
-    },
+      if (element.interactive) {
+        // イベント発火対象のイベントの配列を取得
+        var targetEvents = this._checkPoint(element, p);
+        targetEvents.forEach(function(event) {
+          // targetを発火元の要素に設定
+          event.target = element;
+          // 発火元から root 要素まで発火
+          event.path.some(function(capturedElement) {
+            capturedElement.fire(event);
+            // イベント内で stop が true になった場合は、親要素へ伝播するのを止める
+            return event.stop;
+          });
 
-    _checkPoint: function(obj) {
-      if (this.multiTouch) {
-        this.app.pointers.forEach(function(p) {
-          if (p.id !== null) {
-            this.__checkPoint(obj, p);
+          // イベント終了フラグを立てて、これ以上イベントを発火しないようにする
+          event._end = true;
+
+          // イベント通過設定が true なら、イベントが終了せずに後ろの要素へ行く
+          if (event.pass) {
+            this._initEvent(event.type, p, event.path.slice(0));
           }
         }, this);
       }
-      else {
-        this.__checkPoint(obj, this.app.pointer);
+
+      for (var k in events) {
+        var e = events[k];
+        if (!e._end) {
+          e.path.shift();
+        }
       }
     },
 
-    __checkPoint: function(obj, p) {
-      if (!obj.interactive) return ;
+    _checkPoint: function(obj, p) {
+      var events = this.events;
 
       var prevOverFlag = obj._overFlags[p.id];
       var overFlag = obj.hitTest(p.x, p.y);
       obj._overFlags[p.id] = overFlag;
+      var targetEvents = [];
 
       var e = {
         pointer: p,
@@ -90,43 +161,53 @@ phina.namespace(function() {
       };
 
       if (!prevOverFlag && overFlag) {
-        obj.flare('pointover', e);
-
+        if (!events.pointover._end) {
+          targetEvents.push(events.pointover);
+        }
         if (obj.boundingType && obj.boundingType !== 'none') {
           this._holds.push(obj);
         }
       }
       if (prevOverFlag && !overFlag) {
-        obj.flare('pointout', e);
+        if (!events.pointout._end) {
+          targetEvents.push(events.pointout);
+        }
         this._holds.erase(obj);
       }
 
-      if (overFlag) {
-        if (p.getPointingStart()) {
-          obj._touchFlags[p.id] = true;
-          obj.flare('pointstart', e);
-          // クリックフラグを立てる
-          obj._clicked = true;
+      if (overFlag && p.getPointingStart()) {
+        obj._touchFlags[p.id] = true;
+        if (!events.pointstart._end) {
+          targetEvents.push(events.pointstart);
         }
+        // クリックフラグを立てる
+        obj._clicked = true;
       }
 
       if (obj._touchFlags[p.id]) {
-        obj.flare('pointstay', e);
-        if (p._moveFlag) {
-          obj.flare('pointmove', e);
+        if (!events.pointstay._end) {
+          targetEvents.push(events.pointstay);
+        }
+        if (!events.pointmove._end && p._moveFlag) {
+          targetEvents.push(events.pointmove);
         }
       }
 
-      if (obj._touchFlags[p.id]===true && p.getPointingEnd()) {
+      if (obj._touchFlags[p.id] === true && p.getPointingEnd()) {
         obj._touchFlags[p.id] = false;
-        obj.flare('pointend', e);
-
-        if (phina.isMobile() && obj._overFlags[p.id]) {
+        if (!events.pointend._end) {
+          targetEvents.push(events.pointend);
+        }
+        if (phina.isMobile() && overFlag) {
           obj._overFlags[p.id] = false;
-          obj.flare('pointout', e);
+          if (!events.pointout._end) {
+            targetEvents.push(events.pointout);
+          }
           this._holds.erase(obj);
         }
       }
+
+      return targetEvents;
     },
   });
 

--- a/src/app/interactive.js
+++ b/src/app/interactive.js
@@ -148,17 +148,10 @@ phina.namespace(function() {
 
     _checkPoint: function(obj, p) {
       var events = this.events;
-
       var prevOverFlag = obj._overFlags[p.id];
       var overFlag = obj.hitTest(p.x, p.y);
       obj._overFlags[p.id] = overFlag;
       var targetEvents = [];
-
-      var e = {
-        pointer: p,
-        interactive: this,
-        over: overFlag,
-      };
 
       if (!prevOverFlag && overFlag) {
         if (!events.pointover._end) {

--- a/src/util/eventdispatcher.js
+++ b/src/util/eventdispatcher.js
@@ -82,7 +82,9 @@ phina.namespace(function() {
      * @param {String} event.type カスタムイベントの名前
      */
      fire: function(e) {
-      e.target = this;
+       if (!e.target) {
+         e.target = this;
+       }
       var oldEventName = 'on' + e.type;
       if (this[oldEventName]) this[oldEventName](e);
       

--- a/test/game/index.html
+++ b/test/game/index.html
@@ -228,11 +228,13 @@
   var run = function(path) {
     var p = path.join('/');
     var code = (function() {
-      var code = th.code(p);
-      var lines = code.split('\n');
-      lines.splice(0, 1);
-      lines.splice(lines.length-1, 1);
-      return lines.join('\n');
+      var codes = [th.preparedCode(p), th.code(p)];
+      return codes.map(function(code) {
+        var lines = code.split('\n');
+        lines.splice(0, 1);
+        lines.splice(lines.length - 1, 1);
+        return lines.join('\n');
+      }).join('\n');
     })();
 
     var a = $.ajax({

--- a/test/game/index.html
+++ b/test/game/index.html
@@ -35,6 +35,7 @@
 
     <!-- test files -->
     <script src='src/app.js'></script>
+    <script src='src/interactive.js'></script>
     <script src='src/geom.js'></script>
     <script src='src/display.js'></script>
     <script src='src/ui.js'></script>

--- a/test/game/src/interactive.js
+++ b/test/game/src/interactive.js
@@ -1,0 +1,250 @@
+th.describe("Interactive", function() {
+  th.prepare(function() {
+    var events = [
+      'pointstart',
+      'pointmove',
+      'pointstay',
+      'pointend',
+      'pointover',
+      'pointout',
+      // 'click', // クリックは完全に対応していない
+    ];
+    this.addTitle = function(text) {
+      phina.display.Label({
+        text: text,
+        x: this.gridX.center(),
+        y: 50,
+      }).addChildTo(this);
+    }
+    this.addLabels = function() {
+      this.labelMap = {};
+      events.forEach(function(eventName, i) {
+        var label = phina.display.Label({
+          x: this.gridX.span(1),
+          y: 100 + i * 28,
+          align: 'left',
+          baseline: 'top',
+          text: eventName + ' : テストしてください',
+          fontSize: 20,
+        }).addChildTo(this);
+
+        label.done = function() {
+          if (label._end) {
+            return ;
+          }
+          label.text = eventName + ' : OK';
+          label.fill = 'blue';
+          label._end = true;
+        };
+
+        label.error = function() {
+          if (label._end) {
+            return ;
+          }
+          label.text = eventName + ' : ERROR';
+          label.fill = 'red';
+          label._end = true;
+        };
+
+        this.labelMap[eventName] = label;
+      }, this);
+    }
+  });  
+  th.it('propagation', function() {
+    this.addTitle('イベントが親要素へ伝播するか');
+    this.addLabels();
+    phina.display.RectangleShape({
+      fill: 'gray',
+      width: 500,
+      height: 500,
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+    var testArea = phina.ui.LabelArea({
+      text: 'この要素上で各テストを行ってください',
+      fill: 'white',
+      backgroundColor: 'blue',
+      verticalAlign: 'center',
+      baseline: 'middle',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    testArea.setInteractive(true);
+    events.forEach(function(eventName) {
+      this.on(eventName, function(e) {
+        if (e.target === testArea) {
+          this.labelMap[eventName].done();
+        }
+      });
+    }, this);
+  });
+
+  th.it('stop', function() {
+    this.addTitle('イベントが親要素へ伝播するのを止める');
+    this.addLabels();
+    phina.display.RectangleShape({
+      fill: 'gray',
+      width: 500,
+      height: 500,
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+    var testArea = phina.ui.LabelArea({
+      text: 'この要素上で各テストを行ってください',
+      fill: 'white',
+      backgroundColor: 'blue',
+      verticalAlign: 'center',
+      baseline: 'middle',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    testArea.setInteractive(true);
+    var self = this;
+    events.forEach(function(eventName) {
+      var label = self.labelMap[eventName];
+      self.on(eventName, function(e) {
+        if (e.target === testArea) {
+          label.error();
+        }
+      });
+      testArea.on(eventName, function(e) {
+        e.stop = true;
+        setTimeout(function() {
+          label.done();
+        }, 100);
+      });
+    });
+  });
+
+  th.it('path', function() {
+    this.addTitle('発火した要素から親要素のpathが正しいか');
+    this.addLabels();
+    this.testName = 'ROOT';
+    var dummyRect = phina.display.RectangleShape({
+      fill: 'gray',
+      width: 500, 
+      height: 500,
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+    dummyRect.testName = 'dummyRect';
+    var testArea = phina.ui.LabelArea({
+      text: 'この要素上でテストしてください',
+      fill: 'white',
+      backgroundColor: 'blue',
+      verticalAlign: 'center',
+      baseline: 'middle',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    testArea.testName = 'testArea';
+
+    dummyRect.setInteractive(true);
+    testArea.setInteractive(true);
+
+    var self = this;
+    events.forEach(function(eventName) {
+      var label = self.labelMap[eventName];
+      self.on(eventName, function(e) {
+        if (self === e.target) {
+          return ;
+        }
+        
+        var pathText = e.path.map(function(elm) {
+          return elm.testName;
+        }).join(',');
+
+        if (pathText === e.target.testName + ',ROOT') {
+          if (testArea === e.target) {
+            label.done();
+          }
+        }
+        else {
+          label.error();
+        }
+        console.log(pathText);
+      })
+    });
+  });
+
+  th.it('cover', function() {
+    this.addTitle('別階層の要素が重なっている時、\n上の要素のみがターゲットになるか');
+    this.addLabels();
+    var dummyRect = phina.display.RectangleShape({
+      fill: 'red',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    var testArea = phina.ui.LabelArea({
+      text: '後ろの要素のイベントが発火しないことをテストしてください\n\n(ERRORにならなければOK)',
+      fill: 'white',
+      fontSize: 20,
+      backgroundColor: 'blue',
+      verticalAlign: 'center',
+      baseline: 'middle',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    dummyRect.width = testArea.width * 0.5;
+    dummyRect.height = testArea.height * 0.5;
+
+    dummyRect.setInteractive(true);
+    testArea.setInteractive(true);
+    testArea.alpha = 0.5;
+
+    var self = this;
+    events.forEach(function(eventName) {
+      var label = self.labelMap[eventName];
+      dummyRect.on(eventName, function(e) {
+        label.error();
+      });
+    });
+  });
+
+  th.it('pass', function() {
+    this.addTitle('発火しても処理を中断せずに、\nさらに別階層の要素のチェックを行う');
+    this.addLabels();
+    var t = ' 同じフレームで発火したらOK';
+    this.labelMap.pointover.text += t;
+    this.labelMap.pointout.text += t;
+
+    var dummyRect = phina.display.RectangleShape({
+      fill: 'red',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+    var testArea = phina.ui.LabelArea({
+      text: '後ろの要素のイベントが発火するかテストしてください\n\n(pointover, pointout は素早く動かす必要があります)',
+      fill: 'white',
+      fontSize: 20,
+      backgroundColor: 'blue',
+      verticalAlign: 'center',
+      baseline: 'middle',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    dummyRect.width = testArea.width * 0.8;
+    dummyRect.height = testArea.height * 0.8;
+
+    dummyRect.setInteractive(true);
+    testArea.setInteractive(true);
+    testArea.alpha = 0.5;
+
+    var self = this;
+    events.forEach(function(eventName) {
+      dummyRect.on(eventName, function(e) {
+        self.labelMap[eventName].done();
+      });
+      testArea.on(eventName, function(e) {
+        e.pass = true;
+      });
+    });
+  });
+
+});

--- a/test/game/src/interactive.js
+++ b/test/game/src/interactive.js
@@ -247,4 +247,46 @@ th.describe("Interactive", function() {
     });
   });
 
+
+  th.it('click', function() {
+    this.addTitle('クリックができるか');
+
+    var dummyRect = phina.display.RectangleShape({
+      fill: 'gray',
+      width: 500,
+      height: 500,
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+    var testArea = phina.ui.LabelArea({
+      text: 'クリックをすると色が変わります',
+      fill: 'white',
+      fontSize: 20,
+      backgroundColor: 'blue',
+      verticalAlign: 'center',
+      baseline: 'middle',
+      x: this.gridX.center(),
+      y: this.gridY.center(2),
+    }).addChildTo(this);
+
+    dummyRect.setInteractive(true);
+    testArea.setInteractive(true);
+
+    testArea.onclick = function(e) {
+      this.backgroundColor = 'aqua';
+    };
+    dummyRect.onclick = function(e) {
+      this.fill = 'blue';
+    };
+
+    this.onclick = function(e) {
+      this.backgroundColor = 'gray';
+    };
+    // click は pointstart で e.pass = true にすると後ろの要素も発火する
+    testArea.onpointstart = function(e) {
+      e.pass = true;
+    };
+
+  });
+
 });

--- a/test/game/testhelper.js
+++ b/test/game/testhelper.js
@@ -12,6 +12,9 @@
   var Suite = function(title, fn) {
     this.title = title;
     this.fn = fn;
+    this.preparedFn = function() {
+
+    };
     this.testMap = {};
   };
   Suite.prototype.run = function(key) {
@@ -48,6 +51,9 @@
 
     return suite;
   };
+  th.prepare = function(fn) {
+    current.preparedFn = fn;
+  };
   th.it = function(title, fn) {
     var suite = current;
     
@@ -67,6 +73,13 @@
     var test = suiteMap[pathes[0]].testMap[pathes[1]];
 
     return test.fn.toString();
+  };
+
+  th.preparedCode = function(path) {
+    var pathes = path.split('/');
+    var fn = suiteMap[pathes[0]].preparedFn;
+
+    return fn.toString();
   };
 
   th.run = function(path) {


### PR DESCRIPTION
## 変更箇所

- EventDispatcherのfireでtargetが既に存在する場合は、上書きしないようにする
- マウスカーソルをhoverに変更するかどうかのチェック方法を変更
- 要素をチェックする順番を逆順に変更
- pointerイベントが一度発火した場合は、 親要素を辿って root の要素までイベントが発火する
- pointerイベントが一度発火した場合は、 別の階層構造の要素に対して_checkPointをしない (重なった要素の一番上のみが発火する)
- イベント処理中にイベントオブジェクトの `stop` フラグを `true` にすると、それ以上は親要素へイベントが伝播しない (`e.stop = true`)
- イベント処理中にイベントオブジェクトの `pass` フラグを `true` にすると、別の階層構造の要素に対して、_checkPointをする (`e.pass = true` で 要素が重なってる場合でも、後ろの要素に対してイベントが発火する)
- clickで重なった要素の要素のイベントを発火させるには `pointstart` で `e.pass = true` にする

## テストの追加変更

- prepare機能を追加 (同じ describe の中で共通のコードを埋め込める)
- Interactiveのテストを追加