### PR TITLE
fix math.randbool

### DIFF
--- a/src/core/math.js
+++ b/src/core/math.js
@@ -143,8 +143,8 @@
    * @param {Number} percent  真になる百分率
    * @return {Boolean} ランダムな真偽値
    */
-  Math.$method("randbool", function(perecent) {
-    return Math.randint(0, 99) < (perecent || 50);
+  Math.$method("randbool", function(percent) {
+    return Math.random() < (percent === undefined ? 50 : percent) / 100;
   });
     
 })();

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -144,7 +144,7 @@
    * @return {Boolean} ランダムな真偽値
    */
   Math.$method("randbool", function(perecent) {
-    return Math.randint(0, 100) < (perecent || 50);
+    return Math.randint(0, 99) < (perecent || 50);
   });
     
 })();


### PR DESCRIPTION
現状だと引数で100%にしたときに1/101の確率でfalseになると思ったので修正しました。