### PR TITLE
fix Gauge Reference Error

### DIFF
--- a/src/ui/gauge.js
+++ b/src/ui/gauge.js
@@ -4,7 +4,7 @@ phina.namespace(function() {
    * @class phina.ui.Gauge
    * @extends phina.display.Shape
    */
-  phina.define('phina.ui.Gauge', {
+  var Gauge = phina.define('phina.ui.Gauge', {
     superClass: 'phina.display.Shape',
 
     init: function(options) {


### PR DESCRIPTION
globalizeしない場合、init内のGaugeの参照でエラーが出るので参照用の変数を追加しました