### PR TITLE
zIndexを指定できるようにした

### DIFF
--- a/src/app/element.js
+++ b/src/app/element.js
@@ -185,6 +185,23 @@ phina.namespace(function() {
       this.awake = false;
       return this;
     },
+
+    /**
+     * @method sortChildren
+     * 指定したプロパティの値で子要素を並べ替えます。
+     */
+    sortChildren: function(str) {
+      this.children.sort(function(a, b) {
+        if (a[str] > b[str]) {
+          return 1;
+        }
+        if (a[str] < b[str]) {
+          return -1;
+        }
+        return 0;
+      });
+    },
+
     /**
      * @method fromJSON
      * JSON 形式を使って自身に子要素を追加することができます。

--- a/src/app/object2d.js
+++ b/src/app/object2d.js
@@ -29,6 +29,7 @@ phina.namespace(function() {
       this.scale    = phina.geom.Vector2(options.scaleX, options.scaleY);
       this.rotation = options.rotation;
       this.origin   = phina.geom.Vector2(options.originX, options.originY);
+      this.zIndex   = options.zIndex;
 
       this._matrix = phina.geom.Matrix33().identity();
       this._worldMatrix = phina.geom.Matrix33().identity();
@@ -264,6 +265,16 @@ phina.namespace(function() {
       return this;
     },
 
+    _applyZindex: function() {
+      if (this.parent) {
+        this.parent.sortChildren('zIndex');
+      } else {
+        this.one('added', function() {
+          this.parent.sortChildren('zIndex');
+        });
+      }
+    },
+
     _accessor: {
       /**
        * @property    x
@@ -316,6 +327,17 @@ phina.namespace(function() {
       scaleY: {
         "get": function()   { return this.scale.y; },
         "set": function(v)  { this.scale.y = v; }
+      },
+
+      /**
+       * @property   zIndex
+       */
+      zIndex: {
+        'get': function()   { return this._zIndex; },
+        'set': function(v)  {
+          this._zIndex = v;
+          this._applyZindex();
+        }
       },
       
       /**
@@ -414,6 +436,7 @@ phina.namespace(function() {
         }
       },
     },
+    
     _static: {
       defaults: {
         x: 0,
@@ -423,6 +446,7 @@ phina.namespace(function() {
         rotation: 0,
         originX: 0.5,
         originY: 0.5,
+        zIndex: 0,
         
         width: 64,
         height: 64,
@@ -430,8 +454,5 @@ phina.namespace(function() {
         boundingType: 'rect',
       },
     },
-
   });
-
-  
 });

--- a/test/game/src/app.js
+++ b/test/game/src/app.js
@@ -97,3 +97,33 @@ th.describe("app.BaseApp", function() {
     }.bind(this));
   });
 });
+
+th.describe('app.Object2D', function() {
+  
+  th.it('zIndex', function() {
+
+    var object2d = [];
+
+    for (var i = 0; i <= 4; i ++) {
+      object2d[i] = phina.display.RectangleShape({
+        x: 320 + 20 * (i - 2),
+        y: 480 + 20 * (i - 2)
+      }).addChildTo(this);
+    }
+
+    object2d[0].zIndex = 4;
+
+    object2d[5] = phina.display.RectangleShape({
+      x: 320 + 20 * 3,
+      y: 480 + 20 * 3,
+      zIndex: -2
+    });
+
+    var self = this;
+
+    this.tweener.wait(1000)
+    .call(function() {
+      object2d[5].addChildTo(self);
+    });
+  });
+});


### PR DESCRIPTION
CSSのようなzIndexがあると便利だなと思ったので実装しました。

zIndexプロパティが変更されたときに親のchildrenをソートするようになっています。
親がないときはaddedイベントが起きた時に親のchildrenをソートします。

ただパフォーマンス上どうかなというのはあるのでソートをするタイミングは手動でもいい気もします。
その場合、親に子要素を自動でソートするのかのフラグがあるといいと思うのですが、そうすると Scene 
 は `phina.app.Object2D` を継承していないので `phina.app.Element` にそのフラグをつける必要があります。しかし、それだとどこまでが `Element` でどこからが `Object2D` なのかが良くわからなくなります。