### PR TITLE
phina.ui.Gaugeの初期化修正

### DIFF
--- a/src/ui/gauge.js
+++ b/src/ui/gauge.js
@@ -8,7 +8,7 @@ phina.namespace(function() {
     superClass: 'phina.display.Shape',
 
     init: function(options) {
-      options = ({}).$safe(options || {}, Gauge.defaults);
+      options = ({}).$safe(options || {}, phina.ui.Gauge.defaults);
       
       this.superInit(options);
 


### PR DESCRIPTION
phina.ui.Gaugeで初期化時のデフォルトパラメータに名前空間名が付与されていない為、
phina.globalize()してない場合にエラーとなるのを修正しました。
