### PR TITLE
Flow#thenの挙動を修正

### DIFF
--- a/src/util/flow.js
+++ b/src/util/flow.js
@@ -79,7 +79,7 @@
             });
           }
           else {
-            flow.resolve(arg);
+            flow.resolve(resultValue);
           }
         });
 


### PR DESCRIPTION
[#232](https://github.com/phinajs/phina.js/issues/232)の修正です。
ステータスがresolvedでなくthenに渡す関数がflowのインスタンスを返さない場合、一つ前の結果が返される挙動を修正しました。