### PR TITLE
CountScene のオプションに配列を渡すと逆順に書き換えられる問題の修正

### DIFF
--- a/src/game/countscene.js
+++ b/src/game/countscene.js
@@ -37,7 +37,7 @@ phina.namespace(function() {
       });
 
       if (options.count instanceof Array) {
-        this.countList = options.count.reverse();
+        this.countList = options.count.clone().reverse();
       }
       else {
         this.countList = Array.range(1, options.count+1);


### PR DESCRIPTION
小ネタです。

CountScene にオプションとして下記のように配列を渡すと逆順に書き換えられてしまいましたので、修正してみました。

```javascript
var countList = [ 3, 2, 1 ];

this.app.pushScene(

  CountScene({count: countList})  // ここで countList の中身が逆順になる

);
```

なお動くサンプルは下記においてあります。

[CountScene 確認2 | Runstant](http://runstant.com/Hansel/projects/b66b6839)
