### PR TITLE
Add pixelated support for Mozilla Firefox

### DIFF
--- a/src/display/canvasapp.js
+++ b/src/display/canvasapp.js
@@ -47,8 +47,14 @@ phina.namespace(function() {
 
       if (options.pixelated) {
         // チラつき防止
+        // ドット絵ゲームのサポート
         // https://drafts.csswg.org/css-images/#the-image-rendering
-        this.domElement.style.imageRendering = 'pixelated';
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering#Browser_compatibility
+        if (navigator.userAgent.match(/Firefox\/\d+/)) {
+          this.domElement.style.imageRendering = 'crisp-edges';
+        } else {
+          this.domElement.style.imageRendering = 'pixelated';
+        }
       }
 
       // pushScene, popScene 対策


### PR DESCRIPTION
The `image-rendering` css property has some different possible values depending on the browser.

- The `pixelated` value works only for Chromium based browsers (Google Chrome, Opera and Vivaldi).

- Mozilla Firefox uses a different name with vendor prefix.

- Microsoft browsers don't support it :/

- Apple Safari uses a different name but I can't test it, so I'm adding only Firefox support for now.

Thanks in advance :)