### PR TITLE
[feature] add imageSmoothing option for DisplayScene

### DIFF
--- a/src/display/displayscene.js
+++ b/src/display/displayscene.js
@@ -17,7 +17,7 @@ phina.namespace(function() {
       this.canvas.setSize(params.width, params.height);
       this.renderer = phina.display.CanvasRenderer(this.canvas);
       this.backgroundColor = (params.backgroundColor) ? params.backgroundColor : null;
-      
+
       this.width = params.width;
       this.height = params.height;
       this.gridX = phina.util.Grid(params.width, 16);
@@ -30,6 +30,13 @@ phina.namespace(function() {
       };
       this._overFlags = {};
       this._touchFlags = {};
+
+      var ctx = this.canvas.context;
+      if (params.imageSmoothing === false) {
+        ctx.imageSmoothingEnabled = false;
+        ctx.webkitImageSmoothingEnabled = false;
+        ctx.msImageSmoothingEnabled = false;
+      }
     },
 
     hitTest: function() {
@@ -50,6 +57,7 @@ phina.namespace(function() {
       defaults: {
         width: 640,
         height: 960,
+        imageSmoothing: true,
       },
     }
 


### PR DESCRIPTION
canvasの仕様としてドット絵を拡大した際、微妙にぼやけてしまう問題があります。
これを、DisplaySceneのもつcanvasのimageSmoothingEnabledを切ることでクリアに表示させるオプションを追加しました。
![phina-imageSmoothing-none](https://user-images.githubusercontent.com/10734131/58649946-6fe9fb80-8348-11e9-9e16-6341226a25af.png)
↓切った場合
![phina-imageSmoothing](https://user-images.githubusercontent.com/10734131/58649929-66f92a00-8348-11e9-90fb-abed2be53451.png)

DisplayScene用のオプションですが、基本的にはGameAppのオプションとして渡して使うことを想定しています。

```js
var app = GameApp({
    backgroundColor: "skyblue",
    imageSmoothing: false
});
```

確認用：https://runstant.com/pentamania/projects/2ef8f641
chrome, firefox, MS edgeで確認済みです。
よろしくお願いいたします！