### PR TITLE
touchStart判定が二重になってしまうバグの修正

### DIFF
--- a/src/input/touch.js
+++ b/src/input/touch.js
@@ -156,20 +156,23 @@
     },
 
     update: function() {
-      this.touches.forEach(function(touch) {
-        if (!touch.released) {
-          touch.update();
+      if (this.touches.length > 0) {
+        var clone = this.touches.slice(0);
+        clone.forEach(function(touch) {
+          if (!touch.released) {
+            touch.update();
 
-          if (touch.flags === 0) {
-            touch.released = true;
+            if (touch.flags === 0) {
+              touch.released = true;
+            }
           }
-        }
-        else {
-          touch.released = false;
-          this.removeTouch(touch);
-        }
+          else {
+            touch.released = false;
+            this.removeTouch(touch);
+          }
 
-      }, this);
+        }, this);
+      }
     },
 
     _accessor: {


### PR DESCRIPTION
唐突かつ今更で恐縮なのですが、以前issue（#244）で言及していたバグを修正しました。
（コミット日時から分かり通り、修正したのはだいぶ前なのですが…）
issueではネガティブforループを使った方法を提案してましたが、
処理順番を元の動作と合わせるため、touches配列を一旦クローンする方法で解決いたしました。